### PR TITLE
feat: add Redis connection lifecycle management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+### Changed
+- `IdempotencyGuard.Redis` now owns Redis connection lifecycle internally instead of registering or reusing `IConnectionMultiplexer`
+- Redis connections are created lazily, reconnect on demand, force `AbortOnConnectFail=false`, and throttle reconnect attempts via `RedisIdempotencyOptions.MinimumReconnectInterval`
+
 ## [1.2.3] - 2026-04-03
 ### Added
 - `ReplayedHeaderName` option on `IdempotencyOptions` to customise the response header name added to replayed responses (default: `X-Idempotent-Replayed`)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,10 @@
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
 
     <!-- DI -->
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
 
     <!-- Data stores -->

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ A key `abc-123` with prefix `prod:` is stored as `prod:abc-123`.
 builder.Services.AddIdempotencyGuardRedisStore("localhost:6379");
 ```
 
-Uses atomic Lua scripts for claim operations (SET NX) to guarantee consistency under concurrent access. Expired entries are cleaned up automatically by Redis key TTL — no background cleanup needed.
+Uses atomic Lua scripts for claim operations (SET NX) to guarantee consistency under concurrent access. The Redis package owns the connection lifecycle internally, applies `AbortOnConnectFail=false`, and reconnects lazily with throttling via `RedisIdempotencyOptions.MinimumReconnectInterval`. Expired entries are cleaned up automatically by Redis key TTL — no background cleanup needed.
 
 ### PostgreSQL Store
 

--- a/src/IdempotencyGuard.Redis/IdempotencyGuard.Redis.csproj
+++ b/src/IdempotencyGuard.Redis/IdempotencyGuard.Redis.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 

--- a/src/IdempotencyGuard.Redis/README.md
+++ b/src/IdempotencyGuard.Redis/README.md
@@ -38,17 +38,20 @@ Expired entries are cleaned up automatically by Redis key TTL — no background 
 ## Connection options
 
 ```csharp
-// Takes Connection string which registers IConnectionMultiplexer automatically
-builder.Services.AddIdempotencyGuardRedisStore("localhost:6379,abortConnect=false");
+// The Redis package owns the connection lifecycle internally.
+// AbortOnConnectFail is forced to false for resilient startup/reconnect behavior.
+builder.Services.AddIdempotencyGuardRedisStore("localhost:6379");
 
-// Options callback which resolves IConnectionMultiplexer from configured ConnectionString.
-// If you already have an IConnectionMultiplexer registered, it will be reused.
+// Advanced options
 builder.Services.AddIdempotencyGuardRedisStore(options =>
 {
-    options.ConnectionString = "localhost:6379,abortConnect=false";
+    options.ConnectionString = "localhost:6379,connectTimeout=5000,syncTimeout=1000";
     options.KeyPrefix = "myapp:idempotency:";
+    options.MinimumReconnectInterval = TimeSpan.FromSeconds(60);
 });
 ```
+
+Connections are created lazily on first use. If Redis is temporarily unavailable, the package keeps ownership of the multiplexer and attempts reconnects on demand. Reconnect attempts are throttled by `MinimumReconnectInterval`, and `AbortOnConnectFail = false` is always applied even if the connection string says otherwise.
 
 ## Why Redis
 

--- a/src/IdempotencyGuard.Redis/RedisConnectionManager.cs
+++ b/src/IdempotencyGuard.Redis/RedisConnectionManager.cs
@@ -1,0 +1,147 @@
+using System.Threading;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace IdempotencyGuard.Redis;
+
+internal sealed class RedisConnectionManager : IDisposable, IAsyncDisposable
+{
+    private readonly object _reconnectLock = new();
+    private readonly ILogger<RedisConnectionManager> _logger;
+    private readonly RedisIdempotencyOptions _options;
+
+    private IConnectionMultiplexer? _redisConnection;
+    private ConfigurationOptions? _redisConfigurationOptions;
+    private DateTimeOffset _lastReconnectTime = DateTimeOffset.MinValue;
+    private bool _firstInitialization = true;
+    private bool _disposed;
+
+    public RedisConnectionManager(
+        IOptions<RedisIdempotencyOptions> options,
+        ILogger<RedisConnectionManager> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public IDatabase GetDatabase()
+    {
+        ThrowIfDisposed();
+        return GetConnection().GetDatabase();
+    }
+
+    public Task<TimeSpan> PingAsync()
+    {
+        ThrowIfDisposed();
+        return GetDatabase().PingAsync();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        var connection = Interlocked.Exchange(ref _redisConnection, null);
+        _disposed = true;
+        connection?.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        var connection = Interlocked.Exchange(ref _redisConnection, null);
+        _disposed = true;
+
+        if (connection is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+            return;
+        }
+
+        connection?.Dispose();
+    }
+
+    private IConnectionMultiplexer GetConnection()
+    {
+        var connection = Volatile.Read(ref _redisConnection);
+        if (connection is { IsConnected: true })
+        {
+            return connection;
+        }
+
+        return ForceReconnect();
+    }
+
+    private IConnectionMultiplexer ForceReconnect()
+    {
+        lock (_reconnectLock)
+        {
+            ThrowIfDisposed();
+
+            if (_redisConnection is { IsConnected: true })
+            {
+                return _redisConnection;
+            }
+
+            var utcNow = DateTimeOffset.UtcNow;
+            var elapsed = utcNow - _lastReconnectTime;
+
+            if (!_firstInitialization && elapsed < _options.MinimumReconnectInterval && _redisConnection is not null)
+            {
+                _logger.LogDebug(
+                    "Redis reconnect skipped - last attempt was {ElapsedSeconds}s ago (min interval: {MinIntervalSeconds}s)",
+                    (int)elapsed.TotalSeconds,
+                    (int)_options.MinimumReconnectInterval.TotalSeconds);
+
+                return _redisConnection;
+            }
+
+            _firstInitialization = false;
+            var oldConnection = _redisConnection;
+            _lastReconnectTime = utcNow;
+
+            _redisConnection = ConnectionMultiplexer.Connect(GetConfigurationOptions());
+
+            if (_redisConnection.IsConnected)
+            {
+                _logger.LogInformation("Redis connection established");
+            }
+            else
+            {
+                _logger.LogWarning("Redis multiplexer created but not yet connected; background reconnect is in progress");
+            }
+
+            try
+            {
+                oldConnection?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error disposing previous Redis connection");
+            }
+
+            return _redisConnection;
+        }
+    }
+
+    private ConfigurationOptions GetConfigurationOptions()
+    {
+        return _redisConfigurationOptions ??= BuildConfigurationOptions(_options.ConnectionString);
+    }
+
+    private static ConfigurationOptions BuildConfigurationOptions(string connectionString)
+    {
+        var configurationOptions = ConfigurationOptions.Parse(connectionString, true);
+        configurationOptions.AbortOnConnectFail = false;
+        return configurationOptions;
+    }
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+}

--- a/src/IdempotencyGuard.Redis/RedisIdempotencyOptions.cs
+++ b/src/IdempotencyGuard.Redis/RedisIdempotencyOptions.cs
@@ -4,4 +4,5 @@ public class RedisIdempotencyOptions
 {
     public string ConnectionString { get; set; } = "localhost:6379";
     public string KeyPrefix { get; set; } = "idempotency:";
+    public TimeSpan MinimumReconnectInterval { get; set; } = TimeSpan.FromSeconds(60);
 }

--- a/src/IdempotencyGuard.Redis/RedisIdempotencyStore.cs
+++ b/src/IdempotencyGuard.Redis/RedisIdempotencyStore.cs
@@ -7,13 +7,13 @@ namespace IdempotencyGuard.Redis;
 
 public class RedisIdempotencyStore : IIdempotencyStore
 {
-    private readonly IConnectionMultiplexer _redis;
+    private readonly RedisConnectionManager _redis;
     private readonly RedisIdempotencyOptions _options;
 
     private static readonly LuaScript ClaimScript = LuaScript.Prepare(LoadScript("claim.lua"));
     private static readonly LuaScript CompleteScript = LuaScript.Prepare(LoadScript("complete.lua"));
 
-    public RedisIdempotencyStore(IConnectionMultiplexer redis, IOptions<RedisIdempotencyOptions> options)
+    internal RedisIdempotencyStore(RedisConnectionManager redis, IOptions<RedisIdempotencyOptions> options)
     {
         _redis = redis;
         _options = options.Value;

--- a/src/IdempotencyGuard.Redis/ServiceCollectionExtensions.cs
+++ b/src/IdempotencyGuard.Redis/ServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
-using StackExchange.Redis;
 
 namespace IdempotencyGuard.Redis;
 
@@ -12,12 +11,12 @@ public static class ServiceCollectionExtensions
         Action<RedisIdempotencyOptions> configure)
     {
         services.Configure(configure);
-        services.TryAddSingleton<IConnectionMultiplexer>(sp =>
-        {
-            var options = sp.GetRequiredService<IOptions<RedisIdempotencyOptions>>().Value;
-            return ConnectionMultiplexer.Connect(options.ConnectionString);
-        });
-        services.AddSingleton<IIdempotencyStore, RedisIdempotencyStore>();
+        services.TryAddSingleton<RedisConnectionManager>();
+        services.TryAddSingleton<RedisIdempotencyStore>(sp =>
+            new RedisIdempotencyStore(
+                sp.GetRequiredService<RedisConnectionManager>(),
+                sp.GetRequiredService<IOptions<RedisIdempotencyOptions>>()));
+        services.AddSingleton<IIdempotencyStore>(sp => sp.GetRequiredService<RedisIdempotencyStore>());
         return services;
     }
 
@@ -25,15 +24,9 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         string connectionString)
     {
-        services.AddSingleton<IConnectionMultiplexer>(_ =>
-            ConnectionMultiplexer.Connect(connectionString));
-
-        services.Configure<RedisIdempotencyOptions>(options =>
+        return services.AddIdempotencyGuardRedisStore(options =>
         {
             options.ConnectionString = connectionString;
         });
-
-        services.AddSingleton<IIdempotencyStore, RedisIdempotencyStore>();
-        return services;
     }
 }

--- a/tests/IdempotencyGuard.Integration.Tests/Fixtures/RedisContainerFixture.cs
+++ b/tests/IdempotencyGuard.Integration.Tests/Fixtures/RedisContainerFixture.cs
@@ -1,4 +1,3 @@
-using StackExchange.Redis;
 using Testcontainers.Redis;
 
 namespace IdempotencyGuard.Integration.Tests.Fixtures;
@@ -9,18 +8,15 @@ public class RedisContainerFixture : IAsyncLifetime
         .WithImage("redis:7-alpine")
         .Build();
 
-    public IConnectionMultiplexer Connection { get; private set; } = null!;
+    public string ConnectionString => _container.GetConnectionString();
 
     public async Task InitializeAsync()
     {
         await _container.StartAsync();
-        Connection = await ConnectionMultiplexer.ConnectAsync(_container.GetConnectionString());
     }
 
     public async Task DisposeAsync()
     {
-        if (Connection is not null)
-            await Connection.DisposeAsync();
         await _container.DisposeAsync();
     }
 }

--- a/tests/IdempotencyGuard.Integration.Tests/IdempotencyGuard.Integration.Tests.csproj
+++ b/tests/IdempotencyGuard.Integration.Tests/IdempotencyGuard.Integration.Tests.csproj
@@ -7,6 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />

--- a/tests/IdempotencyGuard.Integration.Tests/Stores/RedisConnectionResilienceTests.cs
+++ b/tests/IdempotencyGuard.Integration.Tests/Stores/RedisConnectionResilienceTests.cs
@@ -1,0 +1,221 @@
+using System.Net;
+using System.Net.Sockets;
+using FluentAssertions;
+using IdempotencyGuard.Redis;
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+using Testcontainers.Redis;
+
+namespace IdempotencyGuard.Integration.Tests.Stores;
+
+public class RedisConnectionResilienceTests
+{
+    [Fact]
+    public async Task store_connects_lazily_and_basic_operations_still_work()
+    {
+        await using var redis = await RedisTestInstance.StartAsync();
+        var provider = CreateServiceProvider(redis.ConnectionString);
+
+        try
+        {
+            var store = provider.GetRequiredService<IIdempotencyStore>();
+            var key = UniqueKey();
+
+            var claimResult = await store.TryClaimAsync(key, "fp-1", TimeSpan.FromMinutes(1));
+            claimResult.Should().BeOfType<ClaimResult.Claimed>();
+
+            var response = CreateResponse(201, """{"ok":true}""");
+            await store.SetResponseAsync(key, response, TimeSpan.FromMinutes(5));
+
+            var storedResponse = await store.GetResponseAsync(key);
+            storedResponse.Should().NotBeNull();
+            storedResponse!.StatusCode.Should().Be(201);
+
+            await store.ReleaseClaimAsync(key);
+
+            var afterRelease = await store.GetResponseAsync(key);
+            afterRelease.Should().BeNull();
+        }
+        finally
+        {
+            await DisposeProviderAsync(provider);
+        }
+    }
+
+    [Fact]
+    public async Task store_recovers_after_redis_container_restart()
+    {
+        var hostPort = GetFreePort();
+        var connectionString = CreateConnectionString(hostPort);
+        await using var firstRedis = await RedisTestInstance.StartAsync(hostPort);
+        var provider = CreateServiceProvider(
+            connectionString,
+            reconnectMinInterval: TimeSpan.FromMilliseconds(250));
+
+        try
+        {
+            var store = provider.GetRequiredService<IIdempotencyStore>();
+
+            await store.TryClaimAsync(UniqueKey(), "warmup", TimeSpan.FromSeconds(10));
+
+            await firstRedis.DisposeAsync();
+
+            Func<Task> operationWhileDown = async () =>
+                await store.TryClaimAsync(UniqueKey(), "fp-1", TimeSpan.FromSeconds(10));
+
+            await operationWhileDown.Should().ThrowAsync<RedisConnectionException>();
+
+            await using var secondRedis = await RedisTestInstance.StartAsync(hostPort);
+
+            await EventuallyAsync(async () =>
+            {
+                var result = await store.TryClaimAsync(UniqueKey(), "fp-2", TimeSpan.FromSeconds(10));
+                result.Should().BeOfType<ClaimResult.Claimed>();
+            });
+        }
+        finally
+        {
+            await DisposeProviderAsync(provider);
+        }
+    }
+
+    [Fact]
+    public async Task store_can_be_resolved_before_redis_is_available()
+    {
+        var hostPort = GetFreePort();
+        var connectionString = CreateConnectionString(hostPort);
+        var provider = CreateServiceProvider(
+            connectionString,
+            reconnectMinInterval: TimeSpan.FromMilliseconds(250));
+
+        try
+        {
+            var store = provider.GetRequiredService<IIdempotencyStore>();
+
+            await using var redis = await RedisTestInstance.StartAsync(hostPort);
+
+            await EventuallyAsync(async () =>
+            {
+                var result = await store.TryClaimAsync(UniqueKey(), "fp-1", TimeSpan.FromSeconds(10));
+                result.Should().BeOfType<ClaimResult.Claimed>();
+            });
+        }
+        finally
+        {
+            await DisposeProviderAsync(provider);
+        }
+    }
+
+    private static IServiceProvider CreateServiceProvider(
+        string connectionString,
+        TimeSpan? reconnectMinInterval = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddIdempotencyGuardRedisStore(options =>
+        {
+            options.ConnectionString = connectionString;
+            options.KeyPrefix = "test:";
+            if (reconnectMinInterval is not null)
+            {
+                options.MinimumReconnectInterval = reconnectMinInterval.Value;
+            }
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task DisposeProviderAsync(IServiceProvider provider)
+    {
+        if (provider is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+    }
+
+    private static async Task EventuallyAsync(Func<Task> assertion, int attempts = 20, int delayMs = 250)
+    {
+        Exception? lastException = null;
+
+        for (var attempt = 0; attempt < attempts; attempt++)
+        {
+            try
+            {
+                await assertion();
+                return;
+            }
+            catch (RedisConnectionException ex)
+            {
+                lastException = ex;
+            }
+            catch (RedisTimeoutException ex)
+            {
+                lastException = ex;
+            }
+            catch (TimeoutException ex)
+            {
+                lastException = ex;
+            }
+
+            await Task.Delay(delayMs);
+        }
+
+        throw new Xunit.Sdk.XunitException($"Redis operation did not succeed after {attempts} attempts. Last error: {lastException}");
+    }
+
+    private static string CreateConnectionString(int hostPort) =>
+        $"localhost:{hostPort},connectTimeout=1000,syncTimeout=1000,asyncTimeout=1000";
+
+    private static int GetFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static string UniqueKey() => $"redis-resilience-{Guid.NewGuid():N}";
+
+    private static IdempotentResponse CreateResponse(int statusCode, string body) =>
+        new()
+        {
+            StatusCode = statusCode,
+            Headers = new Dictionary<string, string[]>
+            {
+                ["Content-Type"] = ["application/json"]
+            },
+            Body = System.Text.Encoding.UTF8.GetBytes(body)
+        };
+
+    private sealed class RedisTestInstance : IAsyncDisposable
+    {
+        private readonly RedisContainer _container;
+
+        private RedisTestInstance(RedisContainer container, string connectionString)
+        {
+            _container = container;
+            ConnectionString = connectionString;
+        }
+
+        public string ConnectionString { get; }
+
+        public static async Task<RedisTestInstance> StartAsync(int? hostPort = null)
+        {
+            var configuredHostPort = hostPort ?? GetFreePort();
+            var container = new RedisBuilder()
+                .WithImage("redis:7-alpine")
+                .WithPortBinding(configuredHostPort, 6379)
+                .Build();
+
+            await container.StartAsync();
+
+            return new RedisTestInstance(container, CreateConnectionString(configuredHostPort));
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _container.DisposeAsync();
+        }
+    }
+}

--- a/tests/IdempotencyGuard.Integration.Tests/Stores/RedisStoreTests.cs
+++ b/tests/IdempotencyGuard.Integration.Tests/Stores/RedisStoreTests.cs
@@ -1,21 +1,35 @@
 using IdempotencyGuard.Integration.Tests.Fixtures;
 using IdempotencyGuard.Redis;
-using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IdempotencyGuard.Integration.Tests.Stores;
 
-public class RedisStoreTests : IdempotencyStoreContractTests, IClassFixture<RedisContainerFixture>
+public class RedisStoreTests : IdempotencyStoreContractTests, IClassFixture<RedisContainerFixture>, IAsyncLifetime
 {
-    private readonly RedisIdempotencyStore _store;
+    private readonly IServiceProvider _serviceProvider;
 
     public RedisStoreTests(RedisContainerFixture fixture)
     {
-        var options = Options.Create(new RedisIdempotencyOptions
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddIdempotencyGuardRedisStore(options =>
         {
-            KeyPrefix = "test:"
+            options.ConnectionString = fixture.ConnectionString;
+            options.KeyPrefix = "test:";
         });
-        _store = new RedisIdempotencyStore(fixture.Connection, options);
+
+        _serviceProvider = services.BuildServiceProvider();
     }
 
-    protected override IIdempotencyStore Store => _store;
+    protected override IIdempotencyStore Store => _serviceProvider.GetRequiredService<IIdempotencyStore>();
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+    }
 }


### PR DESCRIPTION
- `IdempotencyGuard.Redis` now owns Redis connection lifecycle internally instead of registering or reusing `IConnectionMultiplexer`
- Redis connections are created lazily, reconnect on demand, force `AbortOnConnectFail=false`, and throttle reconnect attempts via `RedisIdempotencyOptions.MinimumReconnectInterval`